### PR TITLE
Adds while loop to enable network to *actually* be up

### DIFF
--- a/linuxclientsetup/utilities/set-network
+++ b/linuxclientsetup/utilities/set-network
@@ -414,6 +414,15 @@ function reconfigureNetwork {
 	updateHostname
 	ifup $NETWORKINT
 	current_network_int=$NETWORKINT
+	#Wait for network to *actually* be up
+	PINGCOUNTER=0
+	while [ $PINGCOUNTER <=  15 ]
+	do
+		ping -c 1 $SERVERIP
+		[ $? = 0 ] && break
+		sleep 1
+		let PINGCOUNTER=$PINGCOUNTER+1
+	done
 	mount.cifs //$SERVERIP/netlogon /tmp/netlogon -o guest,nounix
 }
 


### PR DESCRIPTION
Although ifconfig would show the network as up, some hardware will take a few seconds to actually register network connectivity, allowing `set-network` to proceed unhindered, as now `mount-cifs` can properly execute
