### PR TITLE
Fix Mozilla extensions installation

### DIFF
--- a/linuxclientsetup/scripts/client-config
+++ b/linuxclientsetup/scripts/client-config
@@ -255,7 +255,7 @@ if [[ $MAILSERVER ]]; then
 			/opt/karoshi/mozilla/extensions/sogo-integrator/chrome/content/extensions.rdf
 	fi
 	#Install Firetray
-	do_xpi firetray /opt/karoshi/linuxclientsetup/config-files/thunderbird/firetray thunderbird
+	do_xpi /opt/karoshi/linuxclientsetup/config-files/thunderbird/firetray.xpi thunderbird
 
 	if [[ -d /tmp/netlogon/linuxclient/$LINUX_VERSION/thunderbird/extensions ]]; then
 		while read -r -d $'\0' xpi; do
@@ -267,10 +267,10 @@ fi
 
 # Firefox
 #Install Zotero
-do_xpi zotero-4.0.22 /opt/karoshi/linuxclientsetup/config-files/firefox/zotero-main firefox
-do_xpi Zotero-LibreOffice-Plugin-3.5.9 /opt/karoshi/linuxclientsetup/config-files/firefox/zotero-libreplug firefox
+do_xpi /opt/karoshi/linuxclientsetup/config-files/firefox/zotero-4.0.22.xpi firefox
+do_xpi /opt/karoshi/linuxclientsetup/config-files/firefox/Zotero-LibreOffice-Plugin-3.5.9.xpi firefox
 #Install Omnibar
-do_xpi omnibar /opt/karoshi/linuxclientsetup/config-files/firefox/omnibar firefox
+do_xpi /opt/karoshi/linuxclientsetup/config-files/firefox/omnibar.xpi firefox
 
 if [[ -d /tmp/netlogon/linuxclient/$LINUX_VERSION/firefox/extensions ]]; then
 	while read -r -d $'\0' xpi; do


### PR DESCRIPTION
`do_xpi` function is correct, but the invocation of it had invalid parameters

Please review @Eldara98 
