### PR TITLE
Partially Revert "Fix PAM mkhomedir module, remove PAM group module"

### DIFF
--- a/configuration/usr/share/pam-configs/group
+++ b/configuration/usr/share/pam-configs/group
@@ -1,0 +1,6 @@
+Name: Activate /etc/security/group.conf
+Default: yes
+Priority: 256
+Auth-Type: Additional
+Auth:
+	required	pam_group.so use_first_pass


### PR DESCRIPTION
This partially reverts commit 89374472ce877f5fd43d881e067d668f608025fc.

Revert of the removal of pam-group

Fixes #92 