### PR TITLE
Remove dictionary languages from Firefox that don't match machine language

### DIFF
--- a/linuxclientsetup/scripts/client-config
+++ b/linuxclientsetup/scripts/client-config
@@ -283,6 +283,16 @@ if [[ -d /tmp/netlogon/linuxclient/$LINUX_VERSION/firefox/extensions ]]; then
 	done < <(find /tmp/netlogon/linuxclient/$LINUX_VERSION/firefox/extensions -maxdepth 1 -mindepth 1 -name '*.xpi' -print0)
 fi
 
+#Remove unnecessary dictionaries
+machineLang=$(dbus-send --print-reply --system --dest=org.freedesktop.locale1 /org/freedesktop/locale1 org.freedesktop.DBus.Properties.Get string:org.freedesktop.locale1 string:Locale | sed -n '/LANG=/s/.*LANG=\([^\.]*\)\..*/\1/p')
+if [[ -d /usr/lib/firefox/dictionaries ]]; then
+	dpkg-divert --local --add /usr/lib/firefox/dictionaries
+	rm -rf /usr/lib/firefox/dictionaries
+	mkdir /usr/lib/firefox/dictionaries
+	ln -s /usr/share/hunspell/"$machineLang".dic /usr/lib/firefox/dictionaries/"$machineLang".dic
+	ln -s /usr/share/hunspell/"$machineLang".aff /usr/lib/firefox/dictionaries/"$machineLang".aff
+fi
+
 ###########################
 #Create cronjob to shut computer down
 ###########################


### PR DESCRIPTION
Following a fair bit of testing, the dictionaries that Firefox uses for spell-checking are those of Hunspell/Myspell, symlinked to ```/usr/lib/firefox/dictionaries```. Unfortunately, the only way I could find to force Firefox to use the correct spell-checker was to either remove the Hunspell/Myspell dictionaries, or delete the symlinks that Firefox was using and then bring back the relevant dictionaries.
Unfortunately, this does now mean that there is only one spell-check language for Firefox (that defined as the machine language), but the dictionaries are still available for other applications that use them, such as LibreOffice.

Fixes #95 

cc: @Xenopathic 