### PR TITLE
Re-instate software installation controls

### DIFF
--- a/configuration/usr/bin/karoshi-system-upgrade
+++ b/configuration/usr/bin/karoshi-system-upgrade
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+#Copyright (C) 2015 Robin McCorkell <rmccorkell@karoshi.org.uk>
+
+#This file is part of Karoshi Client.
+#
+#Karoshi Client is free software: you can redistribute it and/or modify
+#it under the terms of the GNU Affero General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+#
+#Karoshi Client is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU Affero General Public License for more details.
+#
+#You should have received a copy of the GNU Affero General Public License
+#along with Karoshi Client.  If not, see <http://www.gnu.org/licenses/>.
+
+export DEBIAN_FRONTEND=noninteractive
+
+eval `apt-config shell http_proxy Acquire::http::Proxy`
+export http_proxy
+
+dpkg --configure -a --force-confdef --force-confold
+
+software_install=false
+system_upgrade=false
+if karoshi-manage-flags get software_install >/dev/null; then
+	software_install=true
+fi
+if karoshi-manage-flags get system_upgrade >/dev/null; then
+	system_upgrade=true
+fi
+
+if $software_install || $system_upgrade; then
+	apt-get -q update
+fi
+
+apt_options=( -q -fy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" )
+
+if $software_install; then
+	install_pkgs=( )
+	opts=( "${apt_options[@]}" )
+	if [[ -f /var/lib/karoshi/software/install.list ]]; then
+		while read -r pkg <&11; do
+			case "$pkg" in
+			"#!install")
+				if [[ $install_pkgs ]]; then
+					apt-get install "${opts[@]}" "${install_pkgs[@]}"
+				fi
+				install_pkgs=( )
+				opts=( "${apt_options[@]}" )
+				;;
+			"#!opt "*)
+				opt=${pkg##"#!opt "}
+				opts+=( "$opt" )
+				;;
+			"#"*)
+				;;
+			"")
+				;;
+			*)
+				install_pkgs+=( $pkg )
+				;;
+			esac
+		done 11< /var/lib/karoshi/software/install.list
+	fi
+	if [[ $install_pkgs ]]; then
+		apt-get install "${opts[@]}" "${install_pkgs[@]}"
+	fi
+fi
+
+if $system_upgrade; then
+	apt-get dist-upgrade "${apt_options[@]}"
+fi

--- a/install.sh
+++ b/install.sh
@@ -396,7 +396,7 @@ case "$stage" in
 		laptop-detect os-prober linux-generic
 
 	#Remember to have ubiquity-frontend-* in install/install.list
-	install_packages=( ubiquity ubiquity-casper grub2 )
+	install_pkgs=( ubiquity ubiquity-casper grub2 )
 	opts=( )
 	if [[ -f "$source_dir"/install/install.list ]]; then
 		while read -r pkg <&11; do

--- a/linuxclientsetup/scripts/client-config
+++ b/linuxclientsetup/scripts/client-config
@@ -409,16 +409,35 @@ if ! karoshi-manage-flags get no_update_printers >/dev/null; then
 fi
 
 ############################
-#Update client
+#Software control
 ############################
-#Use update var so that apt-get only updates once
-apt_updated=false
-#Only run if flag file is present
-if [[ -f /tmp/netlogon/linuxclient/$LINUX_VERSION/enable_updates ]]
+software_control_path=/tmp/netlogon/linuxclient/"$LINUX_VERSION"/software/install
+
+karoshi-manage-flags unset system_upgrade
+if [[ -f $software_control_path/all_updates ]] ||
+	( [[ $LOCATION ]] && [[ -f $software_control_path/${LOCATION}_updates ]] )
 then
 	karoshi-manage-flags set system_upgrade
-else
-	karoshi-manage-flags unset system_upgrade
+fi
+
+if [[ ! -d /var/lib/karoshi/software ]]; then
+	mkdir /var/lib/karoshi/software
+fi
+
+karoshi-manage-flags unset software_install
+rm -f /var/lib/karoshi/software/install.list
+
+# If install file does not match known install file, trigger a software install
+function check_install_file {
+	if [[ -f $software_control_path/${1}_install ]]; then
+		karoshi-manage-flags set software_install
+		cat "$software_control_path"/"$1"_software >> /var/lib/karoshi/software/install.list
+	fi
+}
+
+check_install_file all
+if [[ $LOCATION ]]; then
+	check_install_file "$LOCATION"
 fi
 
 ##########################

--- a/linuxclientsetup/utilities/karoshi-system-upgrade.conf
+++ b/linuxclientsetup/utilities/karoshi-system-upgrade.conf
@@ -10,19 +10,4 @@ start on (started karoshi-update)
 console log
 task
 
-pre-start script
-	if ! karoshi-manage-flags get system_upgrade >/dev/null; then
-		stop
-		exit 0
-	fi
-end script
-
-env DEBIAN_FRONTEND=noninteractive
-
-script
-	eval `apt-config shell http_proxy Acquire::http::Proxy`
-	export http_proxy
-	dpkg --configure -a --force-confdef --force-confold
-	apt-get -q update
-	apt-get -q dist-upgrade -fy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
-end script
+exec karoshi-system-upgrade


### PR DESCRIPTION
The following files in netlogon/linuxclient/$LINUX_VERSION/software/install
are checked:
 - all_updates and ${LOCATION}_updates : trigger system update
 - all_install         : install software in all_software
 - ${LOCATION}_install : install software in ${LOCATION}_software

If the MD5 of each *_software file does not match what is already known,
software installation is performed, otherwise it is skipped (as the software
is already installed previously).

The relevant files are stored in /var/lib/karoshi/software:
 - install.list : list of software to install, cat'ed from the *_software files

And control is done by these flags:
 - system_upgrade : perform system upgrade
 - software_install : install software from install.list

Fixes #93 

Needs testing. cc @Eldara98 @mpsharrad 