### PR TITLE
[WIP] Add lockdowns for Firefox preferences

### DIFF
--- a/configuration/usr/lib/firefox/defaults/pref/local-settings.js
+++ b/configuration/usr/lib/firefox/defaults/pref/local-settings.js
@@ -1,0 +1,2 @@
+pref("general.config.obscure_value", 0);
+pref("general.config.filename", "mozilla.cfg");

--- a/configuration/usr/lib/firefox/mozilla.cfg
+++ b/configuration/usr/lib/firefox/mozilla.cfg
@@ -1,0 +1,1 @@
+/var/lib/karoshi/firefox/mozilla.cfg

--- a/linuxclientsetup/scripts/client-config
+++ b/linuxclientsetup/scripts/client-config
@@ -173,7 +173,7 @@ if ! karoshi-manage-flags get no_update_other >/dev/null; then
 fi
 
 #######################
-#Mozilla extensions
+#Mozilla configuration
 #######################
 
 # Mozilla app IDs
@@ -292,6 +292,53 @@ if [[ -L /usr/lib/firefox/dictionaries ]]; then
 	ln -s /usr/share/hunspell/"$machineLang".dic /usr/lib/firefox/dictionaries/"$machineLang".dic
 	ln -s /usr/share/hunspell/"$machineLang".aff /usr/lib/firefox/dictionaries/"$machineLang".aff
 fi
+
+#Lockdown preferences
+firefox_version=`firefox --version | sed 's/^[^0-9]*//'`
+cat > /var/lib/karoshi/firefox/mozilla.cfg << EOF
+//
+EOF
+
+#Proxy server
+if [[ $PROXYSERVER ]]; then
+	cat << FOE >> /var/lib/karoshi/firefox/mozilla.cfg
+pref("network.proxy.http", "$PROXYSERVER.$DNSSUFFIX");
+pref("network.proxy.http_port", 3128);
+pref("network.proxy.ssl", "$PROXYSERVER.$DNSSUFFIX");
+pref("network.proxy.ssl_port", 3128);
+pref("network.proxy.ftp", "$PROXYSERVER.$DNSSUFFIX");
+pref("network.proxy.ftp_port", 3128);
+pref("network.proxy.socks", "$PROXYSERVER.$DNSSUFFIX");
+pref("network.proxy.socks_port", 3128);
+pref("network.proxy.gopher", "$PROXYSERVER.$DNSSUFFIX");
+pref("network.proxy.gopher_port", 3128);
+pref("network.proxy.type", 1);
+pref("network.proxy.no_proxies_on", "localhost, 127.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8, $DNSSUFFIX, $PDC");
+lockPref("browser.startup.homepage", "$PROXYSERVER.$DNSSUFFIX");
+EOF
+else
+	#For no proxy, we want the homepage to be about:home
+	cat << FOE >> /var/lib/karoshi/firefox/mozilla.cfg
+lockPref("browser.startup.homepage", "about:home");
+FOE
+fi
+
+#Remove updated messages and extension checking
+cat << FOE >> /var/lib/karoshi/firefox/mozilla.cfg
+pref("browser.startup.homepage_override.mstone", "$firefox_version");
+pref("extensions.lastAppVersion", "$firefox_version");
+pref("extensions.lastPlatformVersion", "$firefox_version");
+FOE
+
+#Setup Kerberos
+cat << FOE >> /var/lib/karoshi/firefox/mozilla.cfg
+lockPref("network.negotiate-auth.trusted-uris", "$DNSSUFFIX");
+FOE
+
+#Set spellchecker language to machine language
+cat << FOE >> /var/lib/karoshi/firefox/mozilla.cfg
+pref("spellchecker.dictionary", "$machineLang");
+FOE
 
 ###########################
 #Create cronjob to shut computer down

--- a/linuxclientsetup/scripts/pre-session
+++ b/linuxclientsetup/scripts/pre-session
@@ -265,12 +265,6 @@ user_pref('capability.policy.allowclipboard.Clipboard.cutcopy', 'allAccess');
 user_pref('capability.policy.allowclipboard.Clipboard.paste', 'allAccess');" >> ~/.mozilla/firefox/"$firefox_profile"/user.js
 			fi
 
-			#Remove updated messages and extension checking
-			firefox_version=`firefox --version | sed 's/^[^0-9]*//'`
-			echo "user_pref('browser.startup.homepage_override.mstone', '$firefox_version');
-user_pref('extensions.lastAppVersion', '$firefox_version');
-user_pref('extensions.lastPlatformVersion', '$firefox_version');" >> ~/.mozilla/firefox/"$firefox_profile"/user.js
-
 			#Add Zotero settings
 			if [[ $alternate_home ]]; then
 				echo "user_pref('extensions.zotero.dataDir', '~/$alternate_home/.zotero');
@@ -279,32 +273,6 @@ user_pref('extensions.zotero.useDataDir', true);" >> ~/.mozilla/firefox/"$firefo
 
 			#Cache settings
 			echo "user_pref('browser.cache.disk.capacity', 5120);" >> ~/.mozilla/firefox/"$firefox_profile"/user.js
-
-			#Proxy server
-			if [[ $PROXYSERVER ]]; then
-				echo "user_pref('network.proxy.http', '$PROXYSERVER.$DNSSUFFIX');
-user_pref('network.proxy.http_port', 3128);
-user_pref('network.proxy.ssl', '$PROXYSERVER.$DNSSUFFIX');
-user_pref('network.proxy.ssl_port', 3128);
-user_pref('network.proxy.ftp', '$PROXYSERVER.$DNSSUFFIX');
-user_pref('network.proxy.ftp_port', 3128);
-user_pref('network.proxy.socks', '$PROXYSERVER.$DNSSUFFIX');
-user_pref('network.proxy.socks_port', 3128);
-user_pref('network.proxy.gopher', '$PROXYSERVER.$DNSSUFFIX');
-user_pref('network.proxy.gopher_port', 3128);
-user_pref('network.proxy.type', 1);
-user_pref('network.proxy.no_proxies_on', 'localhost, 127.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8, $DNSSUFFIX, $PDC');
-user_pref('browser.startup.homepage', '$PROXYSERVER.$DNSSUFFIX');" >> ~/.mozilla/firefox/"$firefox_profile"/user.js
-			else
-				#For no proxy, we want the homepage to be about:home
-				echo "user_pref('browser.startup.homepage', 'about:home');" >> ~/.mozilla/firefox/"$firefox_profile"/user.js
-			fi
-
-			#Set up Kerberos
-			echo "user_pref('network.negotiate-auth.trusted-uris', '$DNSSUFFIX');" >> ~/.mozilla/firefox/"$firefox_profile"/user.js
-
-			#Set spellcheck language to machine language
-			echo "user_pref('spellchecker.dictionary', '$machineLang');" >> ~/.mozilla/firefox/"$firefox_profile"/user.js
 		fi
 	fi
 


### PR DESCRIPTION
This commit takes into account the ability of Firefox to use autoconfig files to lockdown preferences, and currently locks down the homepage and the ability of users to install extensions (which is disabled).

Tested by myself and this does work.