### PR TITLE
Move background autostart services to Upstart session init

### DIFF
--- a/configuration/etc/xdg/autostart/karoshi-detect-dvd.desktop
+++ b/configuration/etc/xdg/autostart/karoshi-detect-dvd.desktop
@@ -1,6 +1,0 @@
-[Desktop Entry]
-Type=Application
-Name=Karoshi video DVD detection
-Comment=Detect video DVDs and generate icon
-OnlyShowIn=XFCE;
-Exec=karoshi-detect-dvd

--- a/configuration/etc/xdg/autostart/karoshi-prevent-background-change.desktop
+++ b/configuration/etc/xdg/autostart/karoshi-prevent-background-change.desktop
@@ -1,6 +1,0 @@
-[Desktop Entry]
-Type=Application
-Name=Karoshi background change prevention
-Comment=Prevent XFCE background modification
-OnlyShowIn=XFCE;
-Exec=karoshi-prevent-background-change

--- a/configuration/etc/xdg/upstart/karoshi-detect-dvd.conf
+++ b/configuration/etc/xdg/upstart/karoshi-detect-dvd.conf
@@ -1,0 +1,11 @@
+# Karoshi Detect DVD
+#
+# Generate a desktop icon for video DVDs on XFCE
+
+description "Karoshi Detect DVD"
+author      "Robin McCorkell <rmccorkell@karoshi.org.uk>"
+
+start on (started startxfce4)
+stop on (stopping startxfce4)
+
+exec karoshi-detect-dvd

--- a/configuration/etc/xdg/upstart/karoshi-prevent-background-change.conf
+++ b/configuration/etc/xdg/upstart/karoshi-prevent-background-change.conf
@@ -1,0 +1,11 @@
+# Karoshi Prevent Background Change
+#
+# Prevent XFCE background being changed
+
+description "Karoshi Prevent Background Change"
+author      "Robin McCorkell <rmccorkell@karoshi.org.uk>"
+
+start on (started startxfce4)
+stop on (stopping startxfce4)
+
+exec karoshi-prevent-background-change


### PR DESCRIPTION
Karoshi Detect DVD and Karoshi Prevent Background Change are now being triggered from the Upstart session init, rather than XFCE autostart. This means jobs get shut down properly, even if they show no graphical presence.

Fixes #80 (finally!)

cc @Eldara98 you might be interested if you ever need to start services