### PR TITLE
Fix PAM return codes

### DIFF
--- a/linuxclientsetup/scripts/offline-homes
+++ b/linuxclientsetup/scripts/offline-homes
@@ -21,6 +21,8 @@
 #
 #Website: http://www.karoshi.org.uk
 
+source /opt/karoshi/linuxclientsetup/utilities/pam-common
+
 if [[ ! $PAM_USER ]]; then
 	echo "ERROR: Must be run through pam_exec.so" >&2
 	exit $PAM_CRED_UNAVAIL
@@ -37,15 +39,13 @@ else
 	source /opt/karoshi/linuxclientsetup/paths
 fi
 
-user_info=$(getent passwd "$PAM_USER")
-user_uid=$(cut -d":" -f3 <<< "$user_info")
-user_gid=$(cut -d":" -f4 <<< "$user_info")
-user_home=$(cut -d":" -f6 <<< "$user_info")
-
 #Check for required directories
 if [[ ! -d $KAROSHI_DATA ]]; then
 	echo "ERROR: Missing $KAROSHI_DATA" >&2
 	exit $PAM_SYSTEM_ERR
+fi
+if [[ ! -w $KAROSHI_DATA ]]; then
+	exit $PAM_PERM_DENIED
 fi
 if [[ ! -d $KAROSHI_DATA/$KAROSHI_OFFLINE_HOMES ]]; then
 	echo "$KAROSHI_DATA/$KAROSHI_OFFLINE_HOMES did not exist - creating"
@@ -61,7 +61,7 @@ if [[ ! -d $KAROSHI_DATA/$KAROSHI_OFFLINE_HOMES/flags ]]; then
 	mkdir "$KAROSHI_DATA"/"$KAROSHI_OFFLINE_HOMES"/flags -m 0711
 fi
 
-if ! [[ $user_uid -ge 1000 ]]; then
+if ! [[ $USER_UID -ge 1000 ]]; then
 	echo "User is not a domain user - exiting"
 	exit $PAM_IGNORE
 fi
@@ -70,10 +70,10 @@ if karoshi-manage-flags get offline_mode >/dev/null; then
 	if [[ ! -d $KAROSHI_DATA/$KAROSHI_OFFLINE_HOMES/users/$PAM_USER ]]; then
 		echo "Creating offline home directory for $PAM_USER"
 		mkdir "$KAROSHI_DATA"/"$KAROSHI_OFFLINE_HOMES"/users/"$PAM_USER" -m 0700
-		chown $user_uid:$user_gid "$KAROSHI_DATA"/"$KAROSHI_OFFLINE_HOMES"/users/"$PAM_USER"
+		chown $USER_UID:$USER_GID "$KAROSHI_DATA"/"$KAROSHI_OFFLINE_HOMES"/users/"$PAM_USER"
 	fi
 	touch "$KAROSHI_DATA"/"$KAROSHI_OFFLINE_HOMES"/flags/"$PAM_USER"
-	chown $user_uid:$user_gid "$KAROSHI_DATA"/"$KAROSHI_OFFLINE_HOMES"/flags/"$PAM_USER"
+	chown $USER_UID:$USER_GID "$KAROSHI_DATA"/"$KAROSHI_OFFLINE_HOMES"/flags/"$PAM_USER"
 	chmod 0600 "$KAROSHI_DATA"/"$KAROSHI_OFFLINE_HOMES"/flags/"$PAM_USER"
 else
 	if [[ -f $KAROSHI_DATA/$KAROSHI_OFFLINE_HOMES/flags/$PAM_USER ]] && [[ $(< "$KAROSHI_DATA"/"$KAROSHI_OFFLINE_HOMES"/flags/"$PAM_USER") == "delete" ]]; then

--- a/linuxclientsetup/scripts/virtualbox-mkdir
+++ b/linuxclientsetup/scripts/virtualbox-mkdir
@@ -21,6 +21,8 @@
 #
 #Website: http://www.karoshi.org.uk
 
+source /opt/karoshi/linuxclientsetup/utilities/pam-common
+
 if [[ ! $PAM_USER ]]; then
 	echo "ERROR: Must be run through pam_exec.so" >&2
 	exit $PAM_CRED_UNAVAIL
@@ -37,15 +39,13 @@ else
 	source /opt/karoshi/linuxclientsetup/paths
 fi
 
-user_info=$(getent passwd "$PAM_USER")
-user_uid=$(cut -d":" -f3 <<< "$user_info")
-user_gid=$(cut -d":" -f4 <<< "$user_info")
-user_home=$(cut -d":" -f6 <<< "$user_info")
-
 #Check for required directories
 if [[ ! -d $KAROSHI_DATA ]]; then
 	echo "ERROR: Missing $KAROSHI_DATA" >&2
 	exit $PAM_SYSTEM_ERR
+fi
+if [[ ! -w $KAROSHI_DATA ]]; then
+	exit $PAM_PERM_DENIED
 fi
 if [[ ! -d $KAROSHI_DATA/$KAROSHI_VIRTUALBOX ]]; then
 	echo "$KAROSHI_DATA/$KAROSHI_VIRTUALBOX did not exist - creating"
@@ -61,7 +61,7 @@ if [[ ! -d $KAROSHI_DATA/$KAROSHI_VIRTUALBOX/users ]]; then
 	mkdir "$KAROSHI_DATA"/"$KAROSHI_VIRTUALBOX"/users -m 0755
 fi
 
-if ! [[ $user_uid -ge 1000 ]]; then
+if ! [[ $USER_UID -ge 1000 ]]; then
 	echo "User is not a domain user - exiting"
 	exit $PAM_IGNORE
 fi
@@ -69,7 +69,7 @@ fi
 function make_virtualbox_dir {
 	echo "Creating user folder: '$KAROSHI_DATA/$KAROSHI_VIRTUALBOX/users/$PAM_USER'"
 	mkdir "$KAROSHI_DATA"/"$KAROSHI_VIRTUALBOX"/users/"$PAM_USER" -m 0700
-	chown $user_uid:$user_gid "$KAROSHI_DATA"/"$KAROSHI_VIRTUALBOX"/users/"$PAM_USER"
+	chown $USER_UID:$USER_GID "$KAROSHI_DATA"/"$KAROSHI_VIRTUALBOX"/users/"$PAM_USER"
 }
 
 if [[ ! -d $KAROSHI_DATA/$KAROSHI_VIRTUALBOX/users/$PAM_USER ]]; then

--- a/linuxclientsetup/utilities/pam-common
+++ b/linuxclientsetup/utilities/pam-common
@@ -17,10 +17,41 @@
 #You should have received a copy of the GNU Affero General Public License
 #along with Karoshi Client.  If not, see <http://www.gnu.org/licenses/>.
 
+PAM_SUCCESS=0 #Successful completion.
+PAM_OPEN_ERR=1 #Failure when dynamically loading a service module.
+PAM_SYMBOL_ERR=2 #Symbol not found in service module.
+PAM_SERVICE_ERR=3 #Error in underlying service module.
+PAM_SYSTEM_ERR=4 #System error.
+PAM_BUF_ERR=5 #Memory buffer error.
+PAM_CONV_ERR=6 #Conversation failure.
+PAM_PERM_DENIED=7 #The caller does not possess the required authority.
+PAM_MAXTRIES=8 #Maximum number of tries exceeded.
+PAM_AUTH_ERR=9 #Authentication error.
+PAM_NEW_AUTHTOK_REQD=10 #New authentication token required from user.
+PAM_CRED_INSUFFICIENT=11 #Cannot access authentication database because credentials supplied are insufficient.
+PAM_AUTHINFO_UNAVAIL=12 #Cannot retrieve authentication information.
+PAM_USER_UNKNOWN=13 #The user is not known to the underlying account management module.
+PAM_CRED_UNAVAIL=14 #Cannot retrieve user credentials.
+PAM_CRED_EXPIRED=15 #User credentials have expired.
+PAM_CRED_ERR=16 #Failure setting user credentials.
+PAM_ACCT_EXPIRED=17 #User account has expired.
+PAM_AUTHTOK_EXPIRED=18 #Password expired and no longer usable.
+PAM_SESSION_ERR=19 #Cannot initiate/terminate a PAM session.
+PAM_AUTHTOK_ERR=20 #Error in manipulating authentication token.
+PAM_AUTHTOK_RECOVERY_ERR=21 #Old authentication token cannot be recovered.
+PAM_AUTHTOK_LOCK_BUSY=22 #The authentication token lock is busy.
+PAM_AUTHTOK_DISABLE_AGING=23 #Authentication token ageing is disabled.
+PAM_NO_MODULE_DATA=24 #Module data not found.
+PAM_IGNORE=25 #Ignore this module.
+PAM_ABORT=26 #General PAM failure.
+PAM_TRY_AGAIN=27 #Unable to complete operation. Try again.
+PAM_MODULE_UNKNOWN=28 #Module type unknown.
+PAM_DOMAIN_UNKNOWN=29
+
 # pam_set_env <user>
 function pam_set_env {
 	if (( $# < 1 )); then return 1; fi
-	IFS=":" read -r USER _ _ _ GECOS HOME SHELL < <(getent passwd "$1")
+	IFS=":" read -r USER _ USER_UID USER_GID GECOS HOME SHELL < <(getent passwd "$1")
 }
 
 pam_set_env "$PAM_USER"


### PR DESCRIPTION
PAM return codes have been broken for a while... no real difference in execution, since the Karoshi modues are optional anyway, but it's nice for the code to actually do what it is supposed to. Also introduces write permission checks for virtualbox-mkdir and offline-homes to stop them going silly trying to do things while unprivileged.

Quick code review @Eldara98 ?