### PR TITLE
Instate maximum client name length

### DIFF
--- a/linuxclientsetup/utilities/set-network
+++ b/linuxclientsetup/utilities/set-network
@@ -83,6 +83,10 @@ function getClientSettings {
 			info_alert $"Karoshi Set Network" $"You must enter a client name and network interface"
 			continue
 		fi
+		if (( ${#CLIENT_NAME} > 15 )); then
+			info_alert $"Karoshi Set Network" $"Client name must be 15 characters or less"
+			continue
+		fi
 		if ! ( $dhcp || ( [[ $IPADDR =~ $IPREGEX ]] && [[ $NETMASK =~ $IPREGEX ]] && [[ $GATEWAY =~ $IPREGEX ]] ) ); then
 			info_alert $"Karoshi Set Network" $"You must enter a valid IP address, netmask and gateway, or choose DHCP"
 			continue


### PR DESCRIPTION
Client names should not exceed 15 characters, as this causes issues. Instates maximum length check during ```karoshi-set-network```

Fixes #120 

cc: @Xenopathic 