### PR TITLE
Show Karoshi version in LightDM

### DIFF
--- a/configuration/etc/lightdm/lightdm-gtk-greeter.conf
+++ b/configuration/etc/lightdm/lightdm-gtk-greeter.conf
@@ -9,5 +9,5 @@ xft-hintstyle=slight
 xft-rgba=rgb
 show-indicators=~session;~language;~ally;~power;
 show-clock=true
-clock-format=%d %b, %H:%M
+clock-format=Karoshi Client 4.3        |        %d %B %Y, %H:%M
 keyboard=onboard


### PR DESCRIPTION
The Karoshi Client version is now displayed at the top of the screen in LightDM, to aid tech support staff.

Fixes #125 

cc @jhosier @Eldara98 